### PR TITLE
Remove SGE tmpspace limit which has no default probe

### DIFF
--- a/RNAseqAnalyse.pl
+++ b/RNAseqAnalyse.pl
@@ -519,7 +519,7 @@ foreach my $sample (keys %{$samples}) {
 	print QSUB "\n";
 	
 	if ($opt{mapping} eq "yes") {
-	    print QSUB "##MAPPING\nqsub -l h_rt=08:00:00,h_vmem=100G,tmpspace=100G -pe threaded $opt{nthreads} -o $rundir/$sample/logs -e $rundir/$sample/logs -R yes -N $job_id $rundir/$sample/jobs/$job_id.sh\n\n";
+	    print QSUB "##MAPPING\nqsub -l h_rt=08:00:00,h_vmem=100G -pe threaded $opt{nthreads} -o $rundir/$sample/logs -e $rundir/$sample/logs -R yes -N $job_id $rundir/$sample/jobs/$job_id.sh\n\n";
 	}
 	
 	#get read counts of mapped reads


### PR DESCRIPTION
It wasn't clear to me if this should definitely be removed, but it appears to require some local SGE code. If this has to stay in place for now, please deny this PR and add code/instructions on setting up the tmpspace probe.
